### PR TITLE
Set the permissions on the '/config' directory to avoid errors

### DIFF
--- a/sickrage.sh
+++ b/sickrage.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
+umask 000
+
+chown -R nobody:users /config
 
 exec /sbin/setuser nobody python /opt/sickrage/SickBeard.py --datadir=/config


### PR DESCRIPTION
The `/config` directory was't being set to the correct permissions, resulting in sickrage not being able to start.